### PR TITLE
Better feature detection for SpeechRecognition

### DIFF
--- a/webspeechdemo/webspeechdemo.html
+++ b/webspeechdemo/webspeechdemo.html
@@ -222,11 +222,12 @@ var final_transcript = '';
 var recognizing = false;
 var ignore_onend;
 var start_timestamp;
-if (!('webkitSpeechRecognition' in window)) {
+var SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+if (!SpeechRecognition) {
   upgrade();
 } else {
   start_button.style.display = 'inline-block';
-  var recognition = new webkitSpeechRecognition();
+  var recognition = new SpeechRecognition();
   recognition.continuous = true;
   recognition.interimResults = true;
 


### PR DESCRIPTION
The vendor prefix will eventually be removed, please use `window.SpeechRecognition` if available instead of strictly depending on `window.webkitSpeechRecognition`.

Also is there a way to update the article at http://updates.html5rocks.com/2013/01/Voice-Driven-Web-Apps-Introduction-to-the-Web-Speech-API ? /cc @gshires
